### PR TITLE
Patches

### DIFF
--- a/inc/structs.h
+++ b/inc/structs.h
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/17 21:06:43 by ralves-b          #+#    #+#             */
-/*   Updated: 2022/11/04 21:29:35 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:07:34 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -149,6 +149,7 @@ typedef struct s_object
 	t_vector	*orientation;
 	t_matrix	*transformation;
 	t_matrix	*inverse_transformation;
+	t_matrix	*transposed_inverse;
 	t_material	*material;
 	void		(*intersect)(t_object *, t_ray *, t_intersect **);
 	t_vector	*(*get_normal)(t_object *, t_point *);

--- a/src/parser/scene_to_world.c
+++ b/src/parser/scene_to_world.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/02 11:18:05 by maolivei          #+#    #+#             */
-/*   Updated: 2022/11/04 15:08:09 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:09:42 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ static void	setup_camera(t_cam *camera, t_rt_camera *c)
 	t_vector	*aux;
 	t_vector	*up;
 
-	if (is_equal_double(1.0, c->orientation->y))
+	if (is_equal_double(1, fabs(c->orientation->y)))
 		up = create_vector(1, 0, 0);
 	else
 	{

--- a/src/shape/cone.c
+++ b/src/shape/cone.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/27 13:56:58 by maolivei          #+#    #+#             */
-/*   Updated: 2022/11/04 19:41:27 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:10:05 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ t_vector	*get_cone_normal(t_object *cone, t_point *point)
 		return (create_vector(0, 1, 0));
 	if (distance < 1 && point->y <= (cone->cone.min + EPSILON))
 		return (create_vector(0, -1, 0));
-	y = sqrt((point->x * point->x) + (point->z * point->z));
+	y = sqrt(distance);
 	if (point->y > 0.0)
 		y = -y;
 	return (create_vector(point->x, y, point->z));

--- a/src/shape/shape_constructor.c
+++ b/src/shape/shape_constructor.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/26 19:04:32 by maolivei          #+#    #+#             */
-/*   Updated: 2022/11/01 21:10:48 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:08:23 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ t_object	*create_shape(void)
 	object->orientation = NULL;
 	object->transformation = create_identity_matrix();
 	object->inverse_transformation = create_identity_matrix();
+	object->transposed_inverse = create_identity_matrix();
 	object->material = create_material();
 	return (object);
 }

--- a/src/shape/shape_destructor.c
+++ b/src/shape/shape_destructor.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/23 21:22:11 by maolivei          #+#    #+#             */
-/*   Updated: 2022/11/02 09:58:49 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:09:24 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,5 +21,6 @@ void	destroy_shape(void *object)
 	ft_memfree((void *)&obj->orientation);
 	ft_memfree((void *)&obj->transformation);
 	ft_memfree((void *)&obj->inverse_transformation);
+	ft_memfree((void *)&obj->transposed_inverse);
 	ft_memfree((void *)&obj);
 }

--- a/src/shape/shape_setters.c
+++ b/src/shape/shape_setters.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/23 21:19:55 by maolivei          #+#    #+#             */
-/*   Updated: 2022/10/25 22:37:53 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:08:11 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,9 @@ void	set_object_transformation(t_object *object, t_matrix *transform)
 {
 	free(object->transformation);
 	free(object->inverse_transformation);
+	free(object->transposed_inverse);
 	object->transformation = transform;
 	object->inverse_transformation = inverse_matrix(transform);
+	object->transposed_inverse = transpose_matrix(
+			object->inverse_transformation);
 }

--- a/src/world/world_computations.c
+++ b/src/world/world_computations.c
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/25 14:25:08 by ralves-b          #+#    #+#             */
-/*   Updated: 2022/10/31 11:35:24 by maolivei         ###   ########.fr       */
+/*   Updated: 2022/11/07 01:08:57 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,12 @@ t_vector	*normal_at(t_object *shape, t_point *point)
 	t_vector	*object_normal;
 	t_point		*object_point;
 	t_tuple		*aux;
-	t_matrix	*transposed_inverse;
 
 	object_point = multiply_matrix_tuple(shape->inverse_transformation, point);
 	object_normal = shape->get_normal(shape, object_point);
-	transposed_inverse = transpose_matrix(shape->inverse_transformation);
-	world_normal = multiply_matrix_tuple(transposed_inverse, object_normal);
+	world_normal = multiply_matrix_tuple(
+			shape->transposed_inverse, object_normal);
 	world_normal->w = VECTOR_W;
-	free(transposed_inverse);
 	free(object_normal);
 	free(object_point);
 	aux = world_normal;


### PR DESCRIPTION
Some patches, fixing some problems and improving efficiency.

- Fix the way we calculate the camera orientation so it points the right way
- Use `distance` when calculating cone's `y` axis in `get_cone_normal`
- Add `transposed_inverse` as a member of the `t_object` structure, to reduce the amount of times it is calculated.

Co-authored-by: rodrigo-br <rodrigoab123@gmail.com>